### PR TITLE
chore: ignore gradle wrapper jar

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,3 @@
+gradle/wrapper/gradle-wrapper.jar
+node_modules/
+package-lock.json


### PR DESCRIPTION
## Summary
- ignore gradle/wrapper/gradle-wrapper.jar and node artifacts via .gitignore

## Testing
- `npm test`
- `gradle wrapper` *(fails: Directory '/workspace/SportiManager' does not contain a Gradle build)*

------
https://chatgpt.com/codex/tasks/task_e_689a0fe8ff2483268e6550b8157e4c0a